### PR TITLE
fix error about token.

### DIFF
--- a/autoload/gosh_complete.scm
+++ b/autoload/gosh_complete.scm
@@ -785,7 +785,7 @@
     (cond
       ([eq? #\m kind] (string->symbol (substring token 1 (string-length token))))
       ([eq? #\f kind] (substring token 1 (string-length token)))
-      ([else (errorf "illegal token.[~S]" token)]))))
+      (else (errorf "illegal token.[~S]" token)))))
 
 (define (main args)
   (let-args (cdr args)

--- a/autoload/gosh_complete.scm
+++ b/autoload/gosh_complete.scm
@@ -783,9 +783,9 @@
 (define (convert-token token)
   (let1 kind (string-ref token 0)
     (cond
-      ([eq? #\m kind] (string->symbol (substring token 1 (string-length token))))
-      ([eq? #\f kind] (substring token 1 (string-length token)))
-      (else (errorf "illegal token.[~S]" token)))))
+      [(eq? #\m kind) (string->symbol (substring token 1 (string-length token)))]
+      [(eq? #\f kind) (substring token 1 (string-length token))]
+      [else (errorf "illegal token.[~S]" token)])))
 
 (define (main args)
   (let-args (cdr args)


### PR DESCRIPTION
when booting vim, vimproc would exit in error; this fixes the error.
